### PR TITLE
Returning a not found response

### DIFF
--- a/src/main/java/HandlerAssembler.java
+++ b/src/main/java/HandlerAssembler.java
@@ -3,5 +3,5 @@ import java.util.List;
 
 public class HandlerAssembler {
 
-    public static final List<Handler> GET_ALL_HANDLERS = Arrays.asList(new SimpleGetHandler(), new GetWithBodyHandler(), new MethodOptionsHandler(), new MethodOptionsTwoHandler());
+    public static final List<Handler> GET_ALL_HANDLERS = Arrays.asList(new SimpleGetHandler(), new GetWithBodyHandler(), new MethodOptionsHandler(), new MethodOptionsTwoHandler(), new NotFoundResourceHandler());
 }

--- a/src/main/java/NotFoundResourceHandler.java
+++ b/src/main/java/NotFoundResourceHandler.java
@@ -1,0 +1,20 @@
+import java.util.Arrays;
+import java.util.List;
+
+public class NotFoundResourceHandler extends Handler {
+
+    @Override
+    public String url() {
+        return "/not_found_resource";
+    }
+
+    @Override
+    public List<String> httpMethods() {
+        return Arrays.asList("GET");
+    }
+
+    @Override
+    public String buildResponse() {
+        return new ResponseBuilder().notFound();
+    }
+}

--- a/src/main/java/ResponseBuilder.java
+++ b/src/main/java/ResponseBuilder.java
@@ -2,10 +2,11 @@ public class ResponseBuilder {
 
     private static final String EMPTY_BODY_OUTPUT = "";
     private static final String STATUS_CODE_OK = "HTTP/1.1 200 OK";
+    private static final String STATUS_CODE_NOT_FOUND = "HTTP/1.1 404 Not Found";
     private static final String CRLF = "\r\n";
     private static final String ALLOWED_HEADER = "Allow: ";
     private static final String GET_HEAD_OPTIONS = "GET, HEAD, OPTIONS";
-    private static final String PUT_AND_POST = ", PUT, POST";
+    private static final String PUT_POST = ", PUT, POST";
 
     public String okayWithEmptyBody() {
         return STATUS_CODE_OK + CRLF + CRLF + EMPTY_BODY_OUTPUT;
@@ -16,6 +17,10 @@ public class ResponseBuilder {
     }
 
     public String okayWithHeadersGetHeadOptionsPutPost() {
-        return STATUS_CODE_OK + CRLF + ALLOWED_HEADER + GET_HEAD_OPTIONS + PUT_AND_POST + CRLF + CRLF + EMPTY_BODY_OUTPUT;
+        return STATUS_CODE_OK + CRLF + ALLOWED_HEADER + GET_HEAD_OPTIONS + PUT_POST + CRLF + CRLF + EMPTY_BODY_OUTPUT;
+    }
+
+    public String notFound() {
+        return STATUS_CODE_NOT_FOUND + CRLF + CRLF;
     }
 }

--- a/src/test/java/NotFoundResourceHandlerTest.java
+++ b/src/test/java/NotFoundResourceHandlerTest.java
@@ -1,0 +1,34 @@
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+public class NotFoundResourceHandlerTest {
+
+    NotFoundResourceHandler notFoundResourceHandler;
+
+    @Before
+    public void setUp() {
+        notFoundResourceHandler = new NotFoundResourceHandler();
+    }
+
+    @Test
+    public void getRequestWithNotFoundResourceUrlReturns404NotFound() {
+        String request = "GET /not_found_resource HTTP/1.1";
+        RequestParser requestParser =  new RequestParser(request);
+        Assert.assertEquals("HTTP/1.1 404 Not Found\r\n\r\n", notFoundResourceHandler.handle(requestParser));
+    }
+
+    @Test
+    public void getRequestWithInvalidUrlReturnsNoResponse() {
+        String request = "GET /not_found_resources HTTP/1.1";
+        RequestParser requestParser = new RequestParser(request);
+        Assert.assertEquals("", notFoundResourceHandler.handle(requestParser));
+    }
+
+    @Test
+    public void getWithInvalidHttpMethodReturnsNoResponse() {
+        String request = "HEAD /not_found_resource HTTP/1.1";
+        RequestParser requestParser = new RequestParser(request);
+        Assert.assertEquals("", notFoundResourceHandler.handle(requestParser));
+    }
+}

--- a/src/test/java/ResponseBuilderTest.java
+++ b/src/test/java/ResponseBuilderTest.java
@@ -25,4 +25,9 @@ public class ResponseBuilderTest {
     public void buildResponseWithStatusCode200WithHeadersGetHeadOptionsPutPostAndEmptyBody() {
         Assert.assertEquals("HTTP/1.1 200 OK\r\nAllow: GET, HEAD, OPTIONS, PUT, POST\r\n\r\n", responseBuilder.okayWithHeadersGetHeadOptionsPutPost());
     }
+
+    @Test
+    public void buildResponseWithStatusCode404() {
+        Assert.assertEquals("HTTP/1.1 404 Not Found\r\n\r\n", responseBuilder.notFound());
+    }
 }

--- a/src/test/java/WebServerTest.java
+++ b/src/test/java/WebServerTest.java
@@ -65,4 +65,12 @@ public class WebServerTest {
         OutputStream response = mockServerSocketManager.acceptConnection().getOutputStream();
         Assert.assertThat(response.toString(), containsString("HTTP/1.1 200 OK\r\nAllow: GET, HEAD, OPTIONS, PUT, POST"));
     }
+
+    @Test
+    public void startWebServerGet404ResponseWithGetRequestAndNotFoundResourceUrl() throws IOException {
+        WebServer webServer = buildServerSendRequest("GET /not_found_resource HTTP/1.1");
+        webServer.start(port);
+        OutputStream response = mockServerSocketManager.acceptConnection().getOutputStream();
+        Assert.assertThat(response.toString(), containsString("HTTP/1.1 404 Not Found"));
+    }
 }


### PR DESCRIPTION
Given: I make a GET request to "/not_found_resource"
Then: My response should have status code 404